### PR TITLE
Bumps mocha and args versions to resolve minimist security warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
-  - "11"
+  - "12"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "args": "3.0.2",
+    "args": "^5.0.1",
     "basic-auth-parser": "0.0.2",
     "debug": "^3.2.6"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
+    "mocha": "^7.1.2",
     "pkg": "^4.3.5"
   },
   "pkg": {


### PR DESCRIPTION
This has a very minimal test suite but they still pass on our agent tests that rely on this pass.

